### PR TITLE
Use python's builtin logging instead of dirrectly printing

### DIFF
--- a/r2ai/__init__.py
+++ b/r2ai/__init__.py
@@ -1,1 +1,24 @@
+import os
+import logging
+from rich.logging import RichHandler
+
+
 VERSION = "0.8.2"
+
+# 0 NOTSET, 1 DEBUG, 2 INFO, 3 WARNING, 4 ERROR, 5 CRITICAL; multipied by 10
+LOG_LEVEL = int(os.environ.get('R2AI_LOG', '2')) * 10
+LOG_FILE = os.environ.get('R2AI_LOGFILE', None)
+
+for tag in ["httpx", "openai", "httpcore"]:
+    _logger = logging.getLogger(tag)
+    _logger.setLevel(logging.CRITICAL)
+    _logger.propagate = False  # Disable child loggers too
+
+handlers = [RichHandler()]
+if LOG_FILE:
+    handlers.append(logging.FileHandler(LOG_FILE))
+
+LOGGER = logging.getLogger(__name__)
+logging.basicConfig(format="%(name)s - %(levelname)s - %(message)s",
+                    handlers=handlers)
+LOGGER.setLevel(LOG_LEVEL)

--- a/r2ai/backend/openapi.py
+++ b/r2ai/backend/openapi.py
@@ -1,6 +1,7 @@
 """Implementation for kobaldcpp http api call using openai endpoint."""
 import json
 import requests
+from .. import LOGGER
 
 # MODEL="~/.r2ai.models/Lexi-Llama-3-8B-Uncensored_Q4_K_M.gguf"
 # ./llama-server --in-prefix '### User: ' --prompt 5001 \
@@ -31,4 +32,7 @@ def chat(messages, uri='http://localhost:5001', model='gpt-3.5-turbo', openapiKe
         if "text" in choice:
             return j["choices"][0]["text"]
         return choice["message"]["content"]
+    if "error" in j:
+        error = j["error"]
+        LOGGER.getChild("openapi").error("OpenAIError[%s], %s", error['code'], error['message'])
     return "No response"

--- a/r2ai/index.py
+++ b/r2ai/index.py
@@ -8,6 +8,7 @@ import traceback
 import chromadb
 from unidecode import unidecode
 import sys
+from r2ai import LOGGER
 try:
     from .utils import slurp, syscmdstr
     from .const import R2AI_HISTFILE
@@ -336,8 +337,7 @@ class compute_rarity():
             else:
                 self.words[a] = 1
     def pull_realtime_lines(self, text, keywords, use_vectordb):
-        if self.env["debug"] == "true":
-            print(f"Pulling from mastodon {text}")
+        LOGGER.debug(f"Pulling from mastodon {text}")
         return mastodon_lines(text, keywords, use_vectordb)
 
     def find_matches(self, text, keywords):

--- a/r2ai/large.py
+++ b/r2ai/large.py
@@ -1,4 +1,5 @@
 from .models import get_hf_llm, new_get_hf_llm, get_default_model
+from . import LOGGER
 import re
 import json
 
@@ -10,6 +11,7 @@ class Large:
         self.maxtokens = 5000
         # self.model = "TheBloke/Mistral-7B-Instruct-v0.2-GGUF"
         self.model = "FaradayDotDev/llama-3-8b-Instruct-GGUF"
+        self.logger = LOGGER.getChild(f"large[{self.model}]")
         if ai is not None:
             self.ai = ai
         else:
@@ -62,8 +64,7 @@ class Large:
         msg = f"Considering the sentence \"{text}\" as input, Take the KEYWORDS or combination of TWO words from the given text and respond ONLY a comma separated list of the most relevant words. DO NOT introduce your response, ONLY show the words"
         msg = f"Take \"{text}\" as input, and extract the keywords and combination of keywords to make a search online, the output must be a comma separated list" #Take the KEYWORDS or combination of TWO words from the given text and respond ONLY a comma separated list of the most relevant words. DO NOT introduce your response, ONLY show the words"
         response = mm(msg, stream=False, temperature=0.001, stop="</s>", max_tokens=1750)
-        if self.ai.env["debug"] == "true":
-            print("KWSPLITRESPONSE", response)
+        self.logger.debug(response)
         text0 = response["choices"][0]["text"]
         text0 = text0.replace('"', ",")
         if text0.startswith("."):

--- a/r2ai/repl.py
+++ b/r2ai/repl.py
@@ -13,7 +13,7 @@ import os
 from .tab import tab_init, tab_hist, tab_write, tab_evals
 from .interpreter import Interpreter
 from .pipe import have_rlang, r2lang, r2singleton
-from r2ai import bubble
+from r2ai import bubble, LOGGER
 
 tab_init()
 
@@ -79,7 +79,11 @@ help_message = """Usage: r2ai [-option] ([query] | [script.py])
  r2ai -t [temp]         from 0.0001 to 10 your scale to randomness in my replies
  r2ai -v                show r2ai version (same as ?V)
  r2ai -w ([port])       start webserver (curl -D hello http://localhost:8000)
- r2ai -W ([port])       start webserver in background"""
+ r2ai -W ([port])       start webserver in background
+ r2ai -V (num)          set log level for this session
+                        0: NOTSET, 1: DEBUG, 2: INFO,
+                        3: WARNING, 4: ERROR, 5: CRITICAL
+r2ai -V                 get current log level"""
 
 def myprint(msg, file=None):
     global print_buffer
@@ -444,6 +448,12 @@ def runline(ai, usertext):
             print("r2 is not available", file=sys.stderr)
         else:
             builtins.print(r2_cmd(usertext[1:]))
+    elif usertext.startswith("-V"):
+        arguments = usertext.split()
+        if len(arguments) > 1:
+            LOGGER.setLevel(int(arguments[-1]) * 10)
+        else:
+            print("{0:.0f}".format(LOGGER.level / 10))
     elif usertext.startswith("-"):
         print("Unknown flag. See 'r2ai -h' for help", file=sys.stderr)
     else:


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

Makes use of python's built-in logging library to control which logs get displayed based on an environment variable.

Right now it's a base, and it need to be revised based on what where should go.

Built-in commands are:

LOGGING.debug
LOGGING.info
LOGGING.warn
LOGGING.error
LOGGING.critical

The levels can be controlled at runtime via the -V command, or by R2API_LOG= environment.

Option to also push to a file exists with R2AI_LOGFILE=. 

I'm thinking of making it push to both file and console by default and give r2ai it's own directory in .local. [appdirs](https://pypi.org/project/appdirs/) could make picking up directories easier but can be done manually too.

The logs will be structured/session with names like, r2ai.log (for last session), r2ai.log.1, r2ai.log.2 etc.

What do you think? Maybe also move everything else to it's own config file