### PR TITLE
Remove bind ^I rl_complete for macos

### DIFF
--- a/r2ai/tab.py
+++ b/r2ai/tab.py
@@ -145,10 +145,4 @@ def tab_init():
     readline.set_completer_delims('\t\n;')
     readline.set_completion_display_matches_hook(completer.display_matches)
     #readline.parse_and_bind("bind -e")
-    import platform
-    if platform.system() == "Darwin":
-        # macos tab (libedit)
-        readline.parse_and_bind("bind ^I rl_complete")
-    else:
-        # linux tab (gnu readline)
-        readline.parse_and_bind('tab: complete')
+    readline.parse_and_bind('tab: complete')


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

tab works now, can type b. (Sequoia 15.1). Reject if this breaks it on your mac.