### PR TITLE
make r2ai-plugin work r2pm

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,1 +1,0 @@
-import r2ai.cli

--- a/r2ai/main.py
+++ b/r2ai/main.py
@@ -68,6 +68,7 @@ def run_rcfile_once(ai):
 def main(args, commands, dorepl=True):
 
     os.environ["TOKENIZERS_PARALLELISM"] = "false"
+    os.environ["TRANSFORMERS_NO_ADVISORY_WARNINGS"] = "1"
 
     try:
         r2aihome = os.path.dirname(os.path.realpath(__file__))

--- a/r2ai/plugin.py
+++ b/r2ai/plugin.py
@@ -1,7 +1,22 @@
 """Entrypoint for the r2ai plugin and repl."""
-
+import sys
+import os
 import builtins
 import traceback
+
+current_dir = os.path.dirname(os.path.realpath(__file__))
+parent_dir = os.path.dirname(current_dir)
+sys.path.insert(0, parent_dir)
+os.environ["TRANSFORMERS_NO_ADVISORY_WARNINGS"] = "1"
+try:
+    venv_dir = os.path.join(parent_dir, 'venv')
+    if os.path.exists(venv_dir):
+        site_packages = os.path.join(venv_dir, 'lib', 'python{}.{}'.format(*sys.version_info[:2]), 'site-packages')
+        if os.path.exists(site_packages):
+            sys.path.insert(0, site_packages)
+except Exception:
+    pass
+
 import r2lang
 from r2ai.main import r2ai_singleton, run_rcfile_once, runline, help_message
 

--- a/r2ai/tab.py
+++ b/r2ai/tab.py
@@ -141,10 +141,13 @@ def tab_init():
         pass
     except Exception:
         pass
-    readline.set_completer(completer.complete)
-    readline.set_completer_delims('\t\n;')
-    readline.set_completion_display_matches_hook(completer.display_matches)
-    if readline.__doc__.find("GNU") != -1:
-        readline.parse_and_bind('tab: complete')
-    else:
-        readline.parse_and_bind("bind ^I rl_complete")
+    try:
+        readline.set_completer(completer.complete)
+        readline.set_completer_delims('\t\n;')
+        readline.set_completion_display_matches_hook(completer.display_matches)
+        if readline.__doc__.find("GNU") != -1:
+            readline.parse_and_bind('tab: complete')
+        else:
+            readline.parse_and_bind("bind ^I rl_complete")
+    except Exception as e:
+        pass


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

Since r2pm relies on `pip install .` inside its own environment, plugin doesn't work as the venv may not be active. Ideally, it should install r2ai in the user's current python environment, but that means always pushing up new versions to pypi and users installing with `pip install r2ai`. Anyway, I think this should work in most cases.
