### PR TITLE
Feature/change cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The installation is now splitted into two different targets:
 
 * `make install` will place a symlink in `$BINDIR/r2ai`
 * `make install-decai` will install the decai r2js decompiler plugin
-* `make install-server` will install the decai r2js decompiler plugin
+* `make install-server` will install the r2ai-server
 
 ### Windows
 

--- a/README.md
+++ b/README.md
@@ -146,11 +146,15 @@ Sure, here's a simple ASCII pancake:
 [..]
 ```
 
-In **auto** mode, the AI may instruct r2ai to run various commands. Those commands are run on *your host*, so you are asked to review and agree or disagree to run them:
+In **auto** mode, the AI may instruct r2ai to run various commands. Those commands are run on *your host*, so you are asked to review them: 
 
 ```
-r2ai is going to execute: {'id': 'toolu_01LyMPMdN916mZRTG6gZKNL4', 'type': 'function', 'function': {'name': 'r2cmd', 'arguments': '{"command": "pdf @ fcn.000015d0"}'}}. Agree? (y/N) y
+r2ai is going to execute the following command on the host
+Want to edit? (ENTER to validate) pdf @ fcn.000015d0
+This command will execute on this host: pdf @ fcn.000015d0. Agree? (y/N) y
 ```
+
+If you wish to edit the command, you can do it inline for short one line commands, or an editor will pop up.
 
 
 **Example downloading a free local AI: Mistral 7B v0.2**


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [X ] Mark this if you consider it ready to merge
- [X] I tested it on one of my cases
- [X] I wrote some documentation

**Description**

See https://github.com/radareorg/r2ai/pull/115: @trufae  and @dnakov suggested to be able to *edit* the command r2ai wants to run. This PR is implementing it.

When `auto.ask_to_execute` is `True` (which is the default value), whenever r2ai gets a r2cmd, run_python, run_exec command (or any tool actually), it will display the command the AI wants to run and ask end-user to review/modify it.

If the command is on a single line, edition is directly in the command line.
If the command is multi-line (typically a program), r2ai will automatically open $EDITOR if the end-user wants to edit it.

In a case where the end-user does *not* want to run the command at all, s/he can simply remove the entire command line, and then nothing will edited (but probably that will confuse the AI, and it's likely to ask again, it's preferrable to more or less do something secure that could help the AI in its analysis).

In a case where the end-user is fine with the command, s/he just has to leave the command as is and accept it (confirmation) at the end.

A short video is here: https://asciinema.org/a/sWIyYMhIT1pjKUPXSiTdAIfUN

