### PR TITLE
Doc r2ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ sk-ant-api03-CENSORED
 **Example selecting a remote models:**
 
 ```
-[r2ai:0x00006aa0]> -m anthropic:claude-3-5-sonnet-20241022
+[r2ai:0x00006aa0]> -m anthropic:claude-3-7-sonnet-20250219
 [r2ai:0x00006aa0]> -m openai:gpt-4
 ```
 
@@ -276,6 +276,19 @@ claude
 openapi
 ...
 ```
+
+### Example using a local model and ollama
+
+For example, if Ollama serves model codegeex4:latest (`ollama ls`), set decai API as `ollama` and model `codegeex4:latest`.
+
+```
+[0x00002d30]> decai -e api=ollama
+[0x00002d30]> decai -e model=codegeex4:latest
+[0x00002d30]> decai -q Explain what forkpty does in 2 lines
+The `forkpty` function creates a new process with a pseudo-terminal, allowing the parent to interact with the child via standard input/output/err and controlling its terminal.
+```
+
+
 
 ### Example using a local Mistral model and r2ai-server
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,24 @@ Select TheBloke/Mistral-7B-Instruct-v0.2-GGUF model. See -M and -m flags
 [?] Download to ~/.local/share/r2ai/models? (Y/n): Y
 ```
 
+**Example selecting a local model served by Ollama**
+
+Download a model and make it available through Ollama:
+
+```
+$ ollama ls
+NAME                  ID              SIZE      MODIFIED     
+codegeex4:latest      867b8e81d038    5.5 GB    23 hours ago  
+```
+
+Use it from r2ai by prefixing its name with `ollama/`
+
+```
+[r2ai:0x00002d30]> -m ollama/codegeex4:latest
+[r2ai:0x00002d30]> hi
+Hello! How can I assist you today?
+```
+
 ### Standard/Auto mode
 
 The standard mode is invoked by directly asking the question.
@@ -194,7 +212,16 @@ This command will execute on this host: pdf @ fcn.000015d0. Agree? (y/N) y
 
 If you wish to edit the command, you can do it inline for short one line commands, or an editor will pop up.
 
+### r2ai Configuration settings
 
+List all settings with `-e`
+
+| Key         | Explanation                           |
+| ----------- | ------------------------------------- |
+| debug_level | All verbose messages for level 1. Default is 2 |
+| auto.max_runs | Maximum number of questions the AI is allowed to ask r2 in auto mode. |
+| auto.hide_tool_output | By default false, consequently output of r2cmd, run_python etc is shown. Set to `true` to hide those internal messages. |
+| chat.show_cost | Show the cost of each request to the AI if true |
 
 
 ## Running r2ai-server

--- a/decai/decai.r2.js
+++ b/decai/decai.r2.js
@@ -16,7 +16,19 @@ You can use ollama, llamacpp, r2ai-server, etc
 
 It connects to decai -e host/port via OpenAPI rest endpoints.
 
-### Setting up r2ai-server:
+### Setting up Ollama
+
+Install Ollama and download a model (ollama run xxx). List the model (ollama ls).
+
+Configure decai to use Ollama:
+
+   * decai -e api=ollama
+
+Configure decai to use your model:
+
+   * decai -e model=ollama/MODEL_NAME e.g decai -e model=codegeex4:latest
+
+### Setting up r2ai-server
 
 Install r2ai or r2ai-server with r2pm:
 
@@ -30,18 +42,12 @@ Choose one of the recommended models (after r2pm -r r2ai):
 
 Start the webserver:
 
-   $ r2pm -r r2ai
-   $ echo $CLAUDEAPIKEY > ~/.r2ai.anthropic
-   [r2ai:0x0000000]> -m anthropic:claude-3-5-sonnet-20241022
-   [r2ai:0x0000000]> -w
-   Webserver listening at port 8080
+   * r2pm -r r2ai-server -l r2ai -m granite-8b-code-instruct-4k.Q2_K
 
-You can also make r2ai -w talk to an 'r2ai-server' using this line:
+Use the server for decai:
 
-  [r2ai:0x0000000]> -m openapi:http://localhost:8080
-  [r2ai:0x0000000]> -e http.port=8082
+[0x0000000]> decai -e api=r2ai
 
-  [0x0000000]> decai -e host=http://localhost:8082
 ## Remote backends:
 
 Specify the service to use:
@@ -49,6 +55,7 @@ Specify the service to use:
   * decai -e api=claude
   * decai -e api=hf
   * decai -e api=mistral
+  * decai -e api=ollama
   * list all possible value with decai -e api=?
 
 Write the API keys in corresponding files:

--- a/r2ai/models.py
+++ b/r2ai/models.py
@@ -62,7 +62,7 @@ Uncensored:
 Remote:
 -m openapi:http://localhost:5001
 -m openai:gpt-4
--m anthropic:claude-3-5-sonnet-20241022
+-m anthropic:claude-3-7-sonnet-20250219
 -m bedrock:anthropic.claude-3-5-sonnet-20241022-v1
 -m kobaldcpp:http://localhost:5001
 """
@@ -85,6 +85,7 @@ Anthropic:
 -m anthropic:claude-3-opus-20240229
 -m anthropic:claude-3-sonnet-20240229
 -m anthropic:claude-3-5-sonnet-20241022
+-m anthropic:claude-3-7-sonnet-20250219
 groq:
 -m groq:gemma-7b-it
 -m groq:llama2-70b-4096


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [X] I wrote some documentation

**Description**

This adds documentation for : 

- Use of a model served by Ollama in r2ai or decai
- New default `anthropic:claude-3-7-sonnet-20250219` model
- Some of the most interesting r2ai configuration settings
- In decai, removes a help line concerning set up of r2ai-server with Claude. Not sure the help really worked + Ollama is preferred.


