### PR TITLE
fix: empty command in auto mode with ask_to_execute enabled

### DIFF
--- a/r2ai/auto.py
+++ b/r2ai/auto.py
@@ -178,12 +178,10 @@ Here is some information about the binary to get you started:
 
                             else:
                                 # inline short edit
-                                print(f'r2ai is going to execute the following command on the host')
-                                readline.set_startup_hook(lambda: readline.insert_text(command))
-                                try:
-                                    new_command = input("Want to edit? (ENTER to validate) ")
-                                finally:
-                                    readline.set_startup_hook(None) 
+                                print(f'r2ai is going to execute the following command on the host:')
+                                print(f'> {command}')
+                                
+                                new_command = input(f"Type a new command or press ENTER to use {command} ") or command
 
                             if answer.lower() != 'y':
                                 answer = input(f"\033[91mThis command will execute on this host: {new_command}. Agree? (y/N)\033[0m ")


### PR DESCRIPTION
**Checklist**

- [x] Closing issues: #132 #121
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

When ask_to_execute is enabled in auto mode a prefilled input based on readline is used. This doesn't always work when the used terminal does not fully support readline.
