### PR TITLE
Adding max_input_tokens to auto C

### DIFF
--- a/src/r2ai.c
+++ b/src/r2ai.c
@@ -995,7 +995,9 @@ static int r2ai_init(void *user, const char *input) {
 	r_config_set (core->config, "r2ai.auto.init_commands", "aaa;iI;afl");
 	r_config_set_b (core->config, "r2ai.auto.yolo", false);
 	r_config_set_b (core->config, "r2ai.auto.reset_on_query", false);
+	r_config_set_i (core->config, "r2ai.auto.max_input_tokens", 10000);
 	r_config_set_b (core->config, "r2ai.chat.show_cost", true);
+
 	// Configure HTTP timeout in seconds
 	r_config_set_i (core->config, "r2ai.http.timeout", 120);
 	// Configure HTTP rate limiting and retry parameters


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [x] I've tested it
- [ ] I wrote some documentation

**Description**

When analyzing real binaries, in several cases, there are many functions or long functions. 
This results, in theory, in a very long context, to be processed by the LLM.
In reality, this very long context gets truncated at some point - because nothing is illimited ;-) - but the real issue is that it gets truncated in a wrong place, abruptly. So, the request sent to the LLM is badly formed, or has "too many arguments" or is not correctly closed (there is an opening `"`, but not a closing `"`).
As a consequence, the request cannot be processed and fails.

This patch solves this issue (I believe the issue was not filed, but it's there).
The solution is to *truncate* the context, yes, but in an appropriate place. The best place is to truncate *user-content* or *r2cmd output content*. This is what I do here in r2 `auto.c` where I truncate the initial command, and the future tool outputs if they go above the token limit `r2ai.auto.max_input_tokens`. This new config is added in `r2ai.c`.

Example of message you get when the prompt go badly truncated: (before)

```
ERROR: curl failed: execl: Argument list too long

WARN: Server returned 500 response code
INFO: Retrying request (1/10) after error...
```

Example showing the context got truncated. In this silly test, I truncate the context to 30 tokens, which is absolutely too short to get any good response, but good for a test:


```
[0x004130a0]> pdfj @ main
pdfj @ main
DEBUG: RCoreCmd: {"cmd":"pdfj @ main"}
...
72288,"fcn_last":4273070,"size":10,"opcode":"movabs qword [0x6e94a0], rax","disasm":"movabs qword [obj.U_MAINVARIABLES_TARGET_PATH], rax","bytes":"48a3a0946e0000000000","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0,"refs":[{"addr":7247008,"type":"DATA","perm":"-w-"}]},{"addr":4273064,"ptr":7231728,"val":1,"esil":"1,0x6e58f0,=[4]","refptr":4,"fcn_addr":4272288,"fcn_last":4273069,"size":11,"opcode":"mov dword [0x6e58f0], 1","disasm":"mov dword [obj.U_P_PROJECT1_PARAMC], 1","bytes":"c70425f0586e0001000000","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0,"addrline":{"file":"/home/mazeltof/tmp/Locker//project1.lpr","line":344},"refs":[{"addr":7231728,"type":"DATA","perm":"-w-"}],"xrefs":[{"addr":4272918,"type":"CODE","perm":"--x"},{"addr":4272978,"type":"CODE","perm":"--x"}]},{"addr":4273075,"esil":"0x4141e1,rip,=","refptr":0,"fcn_addr":4272288,"fcn_last":4273075,"size":5,"opcode":"jmp 0x4141e1","disasm":"jmp 0x4141e1","bytes":"e9290e0000","family":"cpu","type":"jmp","reloc":false,"type_num":1,"type2_num":0,"addrline":{"file":"/home/mazeltof/tmp/Locker//project1.lpr","line":345},"jump":4276705,"refs":[{"addr":4276705,"type":"CODE","perm":"--x"}]}]}

DEBUG: Truncating command output to 30 tokens
DEBUG: cmd_output = {"name":"main","size":792,"add
```

This works because `{"name":"main","size":792,"add` is the output of the r2 cmd `pdfj @ main`. and it will be pasted correctly in the context as a string, not regarding the fact it is an incorrect JSON object.

Of course, if contexts are truncated too much, the analysis will remain silly, but it won't make r2 bug any longer.
