### PR TITLE
Added support for local GPT4all API Server to decai

### DIFF
--- a/decai/decai.r2.js
+++ b/decai/decai.r2.js
@@ -873,12 +873,15 @@ Use radare2 to resolve user requests.
   function r2aiGPT4all(msg, hideprompt) {
     // If you are getting an error or no reply from gpt4all, then check and increase the Context Length (restart model for setting to apply)
     const openaiModel = (decaiModel.length > 0) ? decaiModel : "ibm-granite/granite-3.3-8b-instruct-GGUF";
+    // get maxTokens or set 2049 by default
+    const maxTokens = parseInt((maxInputTokens.length > 0) ? maxInputTokens : 2049,10); 
     const query = buildQuery(msg.replace(/\r?\n/g, ''), hideprompt);
     const object = {
       model: openaiModel,
       messages: [
         { "role": "user", "content": query },
       ],
+      "max_tokens": maxTokens
     };
     if (decaiDeterministic) {
       object.frequency_penalty = 0;

--- a/decai/decai.r2.js
+++ b/decai/decai.r2.js
@@ -886,6 +886,7 @@ Use radare2 to resolve user requests.
     if (decaiDeterministic) {
       object.frequency_penalty = 0;
       object.presence_penalty = 0;
+      object.temperature = 0.1;
     }
     const headers = [
       "Accept: application/json",


### PR DESCRIPTION
**Checklist**

- [ ] Closing issue: #198
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**
Setup/how to: 

- I am using a Mac to host GPT4all. So I am using SSH to expose the localhost.

```
ssh -R 4891:127.0.0.1:4891 -N VM_IP
```

- Start GPT4all and in Settings mark Enable local API Server (this is listening on localhost (127.0.0.1) on port 4891. 

Using the PasswordCheck example in your VM start radare2:

```
$ r2 PasswordCheck
```

```
[0x100001b34]> decai -e lang=swift
[0x100001b34]> decai -e baseurl=http://localhost:4891
[0x100001b34]> decai -e api=gpt4all
[0x100001b34]> decai -d
```
