### PR TITLE
Add SOUL.md/IDENTITY.md personality files via -id command

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -43,6 +43,7 @@ endif
 
 OBJS=r2ai.o
 OBJS+=apikeys.o
+OBJS+=claw.o
 OBJS+=llm.o
 OBJS+=auto.o
 OBJS+=json.o

--- a/src/auto.c
+++ b/src/auto.c
@@ -424,14 +424,15 @@ R_IPI void cmd_r2ai_a(RCorePluginSession *cps, const char *user_query) {
 	};
 	r2ai_msgs_add (messages, &user_msg);
 
-	const char *system_prompt = NULL;
-	if (!r_config_get_b (core->config, "r2ai.auto.think")) {
-		system_prompt = r_str_newf ("/no_think\nReasoning: Low\n%s", Gprompt_auto);
-	}
+	const char *base_system = r_config_get (core->config, "r2ai.system");
+	const char *think_prefix = r_config_get_b (core->config, "r2ai.auto.think")
+		? ""
+		: "/no_think\nReasoning: Low\n";
+	char *system_prompt = R_STR_ISNOTEMPTY (base_system)
+		? r_str_newf ("%s%s\n\n%s", think_prefix, base_system, Gprompt_auto)
+		: r_str_newf ("%s%s", think_prefix, Gprompt_auto);
 	process_messages (cps, messages, system_prompt, 1);
-	if (system_prompt) {
-		free ((char *)system_prompt);
-	}
+	free (system_prompt);
 }
 
 // Helper function to display content with length indication for long content

--- a/src/claw.c
+++ b/src/claw.c
@@ -70,6 +70,9 @@ static char *claw_personality(void) {
 }
 
 R_API char *r2ai_claw_system_prompt(const char *base) {
+	if (!r2ai_claw_exists ()) {
+		return strdup (base? base: "");
+	}
 	char *personality = claw_personality ();
 	char *result = r_str_newf ("%s%s", base? base: "", personality);
 	free (personality);

--- a/src/claw.c
+++ b/src/claw.c
@@ -1,0 +1,169 @@
+/* r2ai - Copyright 2026 pancake */
+
+#define R_LOG_ORIGIN "r2ai.claw"
+
+#include "r2ai.h"
+#include "r2ai_priv.h"
+
+#define CLAW_DEFAULT_IDENTITY \
+	"- Name: r2clippy\n" \
+	"- A fun, useful reverse engineering sidekick living inside radare2\n" \
+	"- Speaks short, make jokes, but always goes to the point\n" \
+	"- Loves assembly, expert cracker, eats hex dumps for breakfast and it's smart building clever unix one-liners"
+
+#define CLAW_DEFAULT_SOUL \
+	"- Useful first, fun second\n" \
+	"- Show, don't preach: prefer concrete r2 commands and runnable examples\n" \
+	"- Curious about every binary, never bored\n" \
+	"- Admit when something is unclear instead of guessing"
+
+#define CLAW_PROMPT_RULES \
+	"Output between 2 and 5 short markdown bullet points - be flexible, do not pad. " \
+	"Output ONLY the bullets, no preface, no explanation, no code fences."
+
+typedef struct {
+	const char *rel;
+	const char *tag;
+	const char *def;
+	const char *prompt;
+} ClawFile;
+
+static const ClawFile CLAW_FILES[] = {
+	{ ".config/r2ai/IDENTITY.md", "identity", CLAW_DEFAULT_IDENTITY,
+		"Generate an IDENTITY for a fun and useful reverse engineering assistant living in radare2. "
+		"IDENTITY defines WHO the assistant is: name, vibe, voice, style. "
+		"Be invented, surprising and unique each time. " CLAW_PROMPT_RULES },
+	{ ".config/r2ai/SOUL.md", "soul", CLAW_DEFAULT_SOUL,
+		"Generate a SOUL for a fun and useful reverse engineering assistant living in radare2. "
+		"SOUL defines HOW the assistant behaves: values, opinions, rules, character. "
+		"Useful first, fun second; have a clear personal voice. " CLAW_PROMPT_RULES },
+};
+#define CLAW_NFILES ((int)(sizeof (CLAW_FILES) / sizeof (CLAW_FILES[0])))
+
+R_API bool r2ai_claw_exists(void) {
+	int i;
+	for (i = 0; i < CLAW_NFILES; i++) {
+		char *path = r_file_home (CLAW_FILES[i].rel);
+		bool e = path && r_file_exists (path);
+		free (path);
+		if (e) {
+			return true;
+		}
+	}
+	return false;
+}
+
+static char *claw_personality(void) {
+	RStrBuf *sb = r_strbuf_new ("");
+	int i;
+	for (i = 0; i < CLAW_NFILES; i++) {
+		char *path = r_file_home (CLAW_FILES[i].rel);
+		char *content = path? r_file_slurp (path, NULL): NULL;
+		free (path);
+		r_strbuf_appendf (sb, "\n<%s>\n%s\n</%s>\n",
+			CLAW_FILES[i].tag,
+			content? content: CLAW_FILES[i].def,
+			CLAW_FILES[i].tag);
+		free (content);
+	}
+	return r_strbuf_drain (sb);
+}
+
+R_API char *r2ai_claw_system_prompt(const char *base) {
+	char *personality = claw_personality ();
+	char *result = r_str_newf ("%s%s", base? base: "", personality);
+	free (personality);
+	return result;
+}
+
+static char *claw_generate(RCorePluginSession *cps, const char *prompt, const char *extra) {
+	char *full = R_STR_ISNOTEMPTY (extra)
+		? r_str_newf ("%s\n\nAdditional hints from the user: %s", prompt, extra)
+		: strdup (prompt);
+	char *err = NULL;
+	R2AIArgs args = {
+		.input = full,
+		.system_prompt = "You are a creative writer crafting concise personality files.",
+		.error = &err,
+		.dorag = false
+	};
+	char *res = r2ai (cps, args);
+	free (full);
+	if (err) {
+		R_LOG_ERROR ("%s", err);
+		free (err);
+	}
+	return res;
+}
+
+R_API void r2ai_claw_show(RCorePluginSession *cps) {
+	RCore *core = cps->core;
+	int i;
+	for (i = 0; i < CLAW_NFILES; i++) {
+		char *path = r_file_home (CLAW_FILES[i].rel);
+		char *content = path? r_file_slurp (path, NULL): NULL;
+		if (content) {
+			r_cons_printf (core->cons, "\n=== %s ===\n%s\n", path, content);
+		}
+		free (content);
+		free (path);
+	}
+}
+
+R_API void r2ai_claw_create(RCorePluginSession *cps, const char *user_extra) {
+	if (!r2ai_claw_exists ()) {
+		char *cfg = r_file_home (".config/r2ai");
+		r_sys_mkdirp (cfg);
+		free (cfg);
+		int i;
+		for (i = 0; i < CLAW_NFILES; i++) {
+			const ClawFile *f = &CLAW_FILES[i];
+			R_LOG_INFO ("Generating %s", f->tag);
+			char *text = claw_generate (cps, f->prompt, user_extra);
+			if (R_STR_ISEMPTY (text)) {
+				R_LOG_ERROR ("Failed to generate %s", f->tag);
+				free (text);
+				continue;
+			}
+			char *path = r_file_home (f->rel);
+			if (!path || !r_file_dump (path, (const ut8 *)text, strlen (text), false)) {
+				R_LOG_ERROR ("Cannot write %s", path? path: f->rel);
+			}
+			free (path);
+			free (text);
+		}
+	}
+	r2ai_claw_show (cps);
+	r_cons_printf (cps->core->cons, "\n%s.\n", R2AI_CLAW_HINT);
+}
+
+R_API void r2ai_claw_edit(RCorePluginSession *cps) {
+	if (!r2ai_claw_exists ()) {
+		R_LOG_ERROR ("No personality files, run 'r2ai -id' to generate them first");
+		return;
+	}
+	int i;
+	for (i = 0; i < CLAW_NFILES; i++) {
+		char *path = r_file_home (CLAW_FILES[i].rel);
+		if (path && r_file_exists (path)) {
+			r_cons_editor (cps->core->cons, path, NULL);
+		}
+		free (path);
+	}
+}
+
+R_API void r2ai_claw_delete(RCorePluginSession *cps) {
+	RCore *core = cps->core;
+	if (!r2ai_claw_exists ()) {
+		r_cons_printf (core->cons, "No personality files to delete.\n");
+		return;
+	}
+	int i;
+	for (i = 0; i < CLAW_NFILES; i++) {
+		char *path = r_file_home (CLAW_FILES[i].rel);
+		if (path && r_file_exists (path) && r_file_rm (path)) {
+			r_cons_printf (core->cons, "Deleted %s\n", path);
+		}
+		free (path);
+	}
+}

--- a/src/llm.c
+++ b/src/llm.c
@@ -42,6 +42,7 @@ R_IPI R2AI_ChatResponse *r2ai_llmcall(RCorePluginSession *cps, R2AIArgs args) {
 	RCore *core = cps->core;
 	char *owned_model = NULL;
 	char *owned_provider = NULL;
+	char *owned_system_prompt = NULL;
 	R2AI_ChatResponse *res = NULL;
 
 	// Check if rawtools mode is enabled
@@ -96,10 +97,11 @@ R_IPI R2AI_ChatResponse *r2ai_llmcall(RCorePluginSession *cps, R2AIArgs args) {
 		}
 	}
 
-	// Set system_prompt from config if it's not already set
 	if (!args.system_prompt) {
 		args.system_prompt = r_config_get (core->config, "r2ai.system");
 	}
+	owned_system_prompt = r2ai_claw_system_prompt (args.system_prompt);
+	args.system_prompt = owned_system_prompt;
 	if (!args.messages) {
 		args.messages = r2ai_msgs_new ();
 	}
@@ -176,6 +178,7 @@ R_IPI R2AI_ChatResponse *r2ai_llmcall(RCorePluginSession *cps, R2AIArgs args) {
 cleanup:
 	free (owned_model);
 	free (owned_provider);
+	free (owned_system_prompt);
 	return res;
 }
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -65,6 +65,7 @@ srcs = files(
   'anthropic.c',
   'auto.c',
   'apikeys.c',
+  'claw.c',
   'gemini.c',
   'http.c',
   'json.c',

--- a/src/r2ai.c
+++ b/src/r2ai.c
@@ -613,7 +613,10 @@ R_IPI bool r2ai_init(RCorePluginSession *cps) {
 		core->config, "r2ai.system",
 		"You are a reverse engineer. The user is reversing a binary, using "
 		"radare2. The user will ask questions about the binary and you will "
-		"respond with the answer to the best of your ability.");
+		"respond with the answer to the best of your ability. "
+		"If none of the available tools fit the request, answer directly "
+		"from your own knowledge instead of inventing tool names. Only the "
+		"tools explicitly listed in this conversation exist.");
 	r_config_set (
 		core->config, "r2ai.prompt",
 		"Rewrite this function and respond ONLY with code, replace goto/labels "

--- a/src/r2ai.c
+++ b/src/r2ai.c
@@ -19,6 +19,9 @@ static RCoreHelpMessage help_msg_r2ai = {
 	"r2ai", " -K", "Edit the API keys file",
 	"r2ai", " -h", "Show this help message",
 	"r2ai", " -i [file] [query]", "read file and ask the llm with the given query",
+	"r2ai", " -id [hint]", "generate SOUL.md and IDENTITY.md personality files (optional hint)",
+	"r2ai", " -ide", "edit SOUL.md and IDENTITY.md personality files",
+	"r2ai", " -id-", "delete SOUL.md and IDENTITY.md personality files",
 	"r2ai", " -m [model]", "show selected model, list suggested ones, choose one",
 	"r2ai", " -p [provider]", "set LLM provider (openai, anthropic, gemini, etc.)",
 	"r2ai", " -q", "list available query prompts",
@@ -338,6 +341,19 @@ static bool load_r2airc(RCorePluginSession *cps) {
 	return true;
 }
 
+static bool cmd_r2ai_id(RCorePluginSession *cps, const char *input) {
+	if (r_str_startswith (input, "-id-")) {
+		r2ai_claw_delete (cps);
+	} else if (r_str_startswith (input, "-ide")) {
+		r2ai_claw_edit (cps);
+	} else if (r_str_startswith (input, "-id")) {
+		r2ai_claw_create (cps, r_str_trim_head_ro (input + 3));
+	} else {
+		return false;
+	}
+	return true;
+}
+
 R_API void cmd_r2ai(RCorePluginSession *cps, const char *input) {
 	RCore *core = cps->core;
 	R2AI_State *state = cps->data;
@@ -407,6 +423,7 @@ R_API void cmd_r2ai(RCorePluginSession *cps, const char *input) {
 			}
 			r_vdb_result_free (rs);
 		}
+	} else if (cmd_r2ai_id (cps, input)) {
 	} else if (r_str_startswith (input, "-i")) {
 		cmd_r2ai_i (cps, r_str_trim_head_ro (input + 2));
 	} else if (r_str_startswith (input, "-r")) {

--- a/src/r2ai_priv.h
+++ b/src/r2ai_priv.h
@@ -28,4 +28,13 @@ R_API char *r2ai_apikeys_path(bool *exists);
 R_API void r2ai_apikeys_edit(RCorePluginSession *cps);
 R_API char *r2ai_apikeys_get(const char *provider);
 
+/* claw.c - SOUL.md / IDENTITY.md personality files */
+#define R2AI_CLAW_HINT "use 'r2ai -ide' to edit or 'r2ai -id-' to delete"
+R_API bool r2ai_claw_exists(void);
+R_API char *r2ai_claw_system_prompt(const char *base);
+R_API void r2ai_claw_create(RCorePluginSession *cps, const char *user_extra);
+R_API void r2ai_claw_show(RCorePluginSession *cps);
+R_API void r2ai_claw_edit(RCorePluginSession *cps);
+R_API void r2ai_claw_delete(RCorePluginSession *cps);
+
 #endif

--- a/src/rawtools.c
+++ b/src/rawtools.c
@@ -103,13 +103,12 @@ R2AI_ChatResponse *r2ai_rawtools_llmcall(RCorePluginSession *cps, R2AIArgs args)
 		}
 	}
 
-	char *enhanced_system_prompt = NULL;
-	if (init_output) {
-		enhanced_system_prompt = r_str_newf ("%s\n\n%s\n\n%s", short_system_prompt, init_output, RAWTOOLS_PROMPT);
-	} else {
-		enhanced_system_prompt = r_str_newf ("%s\n\n%s", short_system_prompt, RAWTOOLS_PROMPT);
-	}
+	char *base_prompt = init_output
+		? r_str_newf ("%s\n\n%s\n\n%s", short_system_prompt, init_output, RAWTOOLS_PROMPT)
+		: r_str_newf ("%s\n\n%s", short_system_prompt, RAWTOOLS_PROMPT);
 	free (init_output);
+	char *enhanced_system_prompt = r2ai_claw_system_prompt (base_prompt);
+	free (base_prompt);
 	// Temporarily modify args to use enhanced prompt and no tools (since we're using prompt engineering)
 	R2AIArgs rawtools_args = args;
 	rawtools_args.system_prompt = enhanced_system_prompt;

--- a/src/rawtools.c
+++ b/src/rawtools.c
@@ -82,11 +82,12 @@ R2AI_ChatResponse *r2ai_rawtools_llmcall(RCorePluginSession *cps, R2AIArgs args)
 	}
 	RCore *core = cps->core;
 
-	// Modify the system prompt to include rawtools instructions only if no tool messages
-	const char *original_system_prompt = args.system_prompt;
-
-	// For rawtools, use a shorter system prompt to avoid token limits
-	const char *short_system_prompt = "You are a reverse engineer using radare2. The binary is loaded. Use r2cmd tool for analysis.";
+	const char *user_system = R_STR_ISNOTEMPTY (args.system_prompt)
+		? args.system_prompt
+		: r_config_get (core->config, "r2ai.system");
+	if (R_STR_ISEMPTY (user_system)) {
+		user_system = "You are a reverse engineer using radare2. The binary is loaded. Use r2cmd tool for analysis.";
+	}
 
 	// Check for initial command output in messages
 	char *init_output = NULL;
@@ -104,8 +105,8 @@ R2AI_ChatResponse *r2ai_rawtools_llmcall(RCorePluginSession *cps, R2AIArgs args)
 	}
 
 	char *base_prompt = init_output
-		? r_str_newf ("%s\n\n%s\n\n%s", short_system_prompt, init_output, RAWTOOLS_PROMPT)
-		: r_str_newf ("%s\n\n%s", short_system_prompt, RAWTOOLS_PROMPT);
+		? r_str_newf ("%s\n\n%s\n\n%s", user_system, init_output, RAWTOOLS_PROMPT)
+		: r_str_newf ("%s\n\n%s", user_system, RAWTOOLS_PROMPT);
 	free (init_output);
 	char *enhanced_system_prompt = r2ai_claw_system_prompt (base_prompt);
 	free (base_prompt);
@@ -239,7 +240,6 @@ R2AI_ChatResponse *r2ai_rawtools_llmcall(RCorePluginSession *cps, R2AIArgs args)
 
 		// Modify args to use original system prompt without rawtools enhancement
 		R2AIArgs fallback_args = args;
-		fallback_args.system_prompt = original_system_prompt;
 		fallback_args.tools = args.tools; // Keep tools for fallback
 
 		// Call provider directly

--- a/src/wizard.c
+++ b/src/wizard.c
@@ -135,6 +135,34 @@ static bool wizard_step_setup(RCore *core) {
 	return true;
 }
 
+static void wizard_claw_invoke(RCore *core, const char *extra) {
+	char *cmd = R_STR_ISNOTEMPTY (extra)
+		? r_str_newf ("r2ai -id %s", extra)
+		: strdup ("r2ai -id");
+	r_core_cmd_call (core, cmd);
+	free (cmd);
+}
+
+static bool wizard_step_personality(RCore *core) {
+	if (r2ai_claw_exists ()) {
+		return true;
+	}
+	show_clippy_message (core, "🎭 Want to give r2ai a custom personality?");
+	r_cons_printf (core->cons,
+		"\nr2ai defaults to 'r2clippy'. Later you can %s.\n\n", R2AI_CLAW_HINT);
+	if (!r_cons_yesno (core->cons, 'n', "Generate a custom personality now? (y/N)")) {
+		return true;
+	}
+	r_cons_printf (core->cons,
+		"\nDescribe it in a few words (e.g. 'grumpy pirate hacker'),\n"
+		"or just press Enter to let r2ai pick something at random:\n");
+	const char *desc = r_line_readline (core->cons);
+	char *trimmed = desc? r_str_trim_dup (desc): NULL;
+	wizard_claw_invoke (core, trimmed);
+	free (trimmed);
+	return true;
+}
+
 static bool wizard_step_basic_usage(RCore *core) {
 	show_clippy_message (core, "🧩 Let's learn the basics of AI-powered reversing!");
 
@@ -323,6 +351,10 @@ R_API bool r2ai_wizard(RCore *core) {
 	}
 
 	if (!wizard_step_setup (core)) {
+		return false;
+	}
+
+	if (!wizard_step_personality (core)) {
 		return false;
 	}
 


### PR DESCRIPTION
Introduce claw.c with the logic to generate, edit, delete and load
short openclaw-style personality files stored under
~/.config/r2ai/SOUL.md and ~/.config/r2ai/IDENTITY.md. The new
'r2ai -id [hint]' command asks the LLM to produce both files (any
text after -id is appended to the generation prompts), 'r2ai -ide'
opens them in the editor and 'r2ai -id-' removes them. When the
files exist their contents are appended to the system prompt so the
agents take on the generated persona.