### PR TITLE
Add Vertex AI provider for Gemini and Anthropic models

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -53,6 +53,7 @@ OBJS+=tools.o
 OBJS+=messages.o
 OBJS+=anthropic.o
 OBJS+=gemini.o
+OBJS+=vertex.o
 OBJS+=http.o
 OBJS+=openai.o
 OBJS+=markdown.o

--- a/src/anthropic.c
+++ b/src/anthropic.c
@@ -150,17 +150,21 @@ R_IPI R2AI_ChatResponse *r2ai_anthropic(RCorePluginSession *cps, R2AIArgs args) 
 		R_LOG_DEBUG ("Anthropic API response: %s", res);
 	}
 
-	// Parse the response
-	R2AI_ChatResponse *result = R_NEW0 (R2AI_ChatResponse);
+	R2AI_ChatResponse *result = r2ai_anthropic_parse_response (res, error);
+	free (res);
+	return result;
+}
 
+/* Shared Anthropic response parser -- used by both anthropic.c and vertex.c */
+R_IPI R2AI_ChatResponse *r2ai_anthropic_parse_response(const char *json, char **error) {
+	R2AI_ChatResponse *result = R_NEW0 (R2AI_ChatResponse);
 	R2AI_Message *message = NULL;
 	R2AI_Usage *usage = NULL;
 
-	char *response_copy = strdup (res);
+	char *response_copy = strdup (json);
 	if (response_copy) {
 		RJson *jres = r_json_parse (response_copy);
 		if (jres) {
-			// Create a new message structure
 			message = R_NEW0 (R2AI_Message);
 
 			const RJson *usage_json = r_json_get (jres, "usage");
@@ -184,14 +188,11 @@ R_IPI R2AI_ChatResponse *r2ai_anthropic(RCorePluginSession *cps, R2AIArgs args) 
 
 				RStrBuf *content_buf = r_strbuf_new ("");
 
-				// Check for tool calls in Anthropic response
 				int has_tool_use = 0;
 				int n_tool_calls = 0;
 
-				// Count tool_use blocks to determine array size
 				const RJson *content_array = r_json_get (jres, "content");
 				if (content_array && content_array->type == R_JSON_ARRAY) {
-					// First count the number of tool_use blocks
 					const RJson *content_item = content_array->children.first;
 					while (content_item) {
 						const RJson *type = r_json_get (content_item, "type");
@@ -203,7 +204,6 @@ R_IPI R2AI_ChatResponse *r2ai_anthropic(RCorePluginSession *cps, R2AIArgs args) 
 					}
 				}
 
-				// Allocate tool_calls list if needed
 				if (has_tool_use && n_tool_calls > 0) {
 					message->tool_calls = r_list_new ();
 					if (!message->tool_calls) {
@@ -213,13 +213,11 @@ R_IPI R2AI_ChatResponse *r2ai_anthropic(RCorePluginSession *cps, R2AIArgs args) 
 						r_json_free (jres);
 						free (response_copy);
 						r2ai_message_free (message);
-						free (res);
 						return NULL;
 					}
 					message->tool_calls->free = (RListFree)r2ai_tool_call_free;
 				}
 
-				// Process each content item
 				int tool_idx = 0;
 				if (content_array && content_array->type == R_JSON_ARRAY) {
 					RList *cb = r2ai_content_blocks_new ();
@@ -227,7 +225,6 @@ R_IPI R2AI_ChatResponse *r2ai_anthropic(RCorePluginSession *cps, R2AIArgs args) 
 						r_json_free (jres);
 						free (response_copy);
 						r2ai_message_free (message);
-						free (res);
 						return NULL;
 					}
 					const RJson *content_item = content_array->children.first;
@@ -236,7 +233,6 @@ R_IPI R2AI_ChatResponse *r2ai_anthropic(RCorePluginSession *cps, R2AIArgs args) 
 						if (type && type->type == R_JSON_STRING) {
 							R2AI_ContentBlock *block = R_NEW0 (R2AI_ContentBlock);
 							if (!strcmp (type->str_value, "text")) {
-								// Text content
 								const RJson *text = r_json_get (content_item, "text");
 								if (text && text->type == R_JSON_STRING) {
 									r_strbuf_append (content_buf, text->str_value);
@@ -244,7 +240,6 @@ R_IPI R2AI_ChatResponse *r2ai_anthropic(RCorePluginSession *cps, R2AIArgs args) 
 									block->text = strdup (text->str_value);
 								}
 							} else if (!strcmp (type->str_value, "tool_use") && tool_idx < n_tool_calls) {
-								// Tool call - convert from Anthropic format to OpenAI format
 								const RJson *name = r_json_get (content_item, "name");
 								const RJson *id = r_json_get (content_item, "id");
 								const RJson *input = r_json_get (content_item, "input");
@@ -262,7 +257,6 @@ R_IPI R2AI_ChatResponse *r2ai_anthropic(RCorePluginSession *cps, R2AIArgs args) 
 								}
 
 								if (input && input->type == R_JSON_OBJECT) {
-#if 1
 									char *input_str = r_json_to_string (input);
 									if (input_str) {
 										R_LOG_DEBUG ("Input string: %s", input_str);
@@ -270,17 +264,16 @@ R_IPI R2AI_ChatResponse *r2ai_anthropic(RCorePluginSession *cps, R2AIArgs args) 
 										tc->arguments = strdup (input_str);
 										free (input_str);
 									}
-#endif
 								}
 
 								r_list_append (message->tool_calls, tc);
 								tool_idx++;
 							} else if (!strcmp (type->str_value, "thinking")) {
-								const RJson *data = r_json_get (content_item, "data");
+								const RJson *tdata = r_json_get (content_item, "data");
 								const RJson *thinking = r_json_get (content_item, "thinking");
 								const RJson *signature = r_json_get (content_item, "signature");
-								if (data && data->type == R_JSON_STRING) {
-									block->data = strdup (data->str_value);
+								if (tdata && tdata->type == R_JSON_STRING) {
+									block->data = strdup (tdata->str_value);
 								}
 								if (thinking && thinking->type == R_JSON_STRING) {
 									block->thinking = strdup (thinking->str_value);
@@ -301,10 +294,8 @@ R_IPI R2AI_ChatResponse *r2ai_anthropic(RCorePluginSession *cps, R2AIArgs args) 
 					message->content_blocks = cb;
 				}
 
-				// Store the content
 				message->content = r_strbuf_drain (content_buf);
 
-				// If there's no content and no tool calls, clean up
 				if (!message->content && (!message->tool_calls || r_list_empty (message->tool_calls))) {
 					r2ai_message_free (message);
 					message = NULL;
@@ -315,12 +306,8 @@ R_IPI R2AI_ChatResponse *r2ai_anthropic(RCorePluginSession *cps, R2AIArgs args) 
 		free (response_copy);
 	}
 
-	// Assign message and usage to result
 	result->message = message;
 	result->usage = usage;
-
-	// Free the HTTP response body
-	free (res);
 	return result;
 }
 

--- a/src/llm.c
+++ b/src/llm.c
@@ -22,6 +22,8 @@ static const R2AIProvider r2ai_providers[] = {
 	{ "mistral", "https://api.mistral.ai/v1", R2AI_API_OPENAI_COMPATIBLE, true, true },
 	{ "lmstudio", "http://127.0.0.1:1234/v1", R2AI_API_OPENAI_COMPATIBLE, false, true },
 	{ "deepseek", "https://api.deepseek.com/v1", R2AI_API_OPENAI_COMPATIBLE, true, true },
+	{ "vertex", NULL, R2AI_API_VERTEX_GEMINI, false, false },
+	{ "vertex-anthropic", NULL, R2AI_API_VERTEX_ANTHROPIC, false, false },
 	{ NULL, NULL, R2AI_API_OPENAI_COMPATIBLE, false, false } // sentinel
 };
 
@@ -43,6 +45,7 @@ R_IPI R2AI_ChatResponse *r2ai_llmcall(RCorePluginSession *cps, R2AIArgs args) {
 	char *owned_model = NULL;
 	char *owned_provider = NULL;
 	char *owned_system_prompt = NULL;
+	char *api_key = NULL;
 	R2AI_ChatResponse *res = NULL;
 
 	// Check if rawtools mode is enabled
@@ -79,8 +82,14 @@ R_IPI R2AI_ChatResponse *r2ai_llmcall(RCorePluginSession *cps, R2AIArgs args) {
 		goto cleanup;
 	}
 
-	char *api_key = NULL;
-	if (prov->requires_api_key) {
+	bool is_vertex = (prov->api_type == R2AI_API_VERTEX_GEMINI || prov->api_type == R2AI_API_VERTEX_ANTHROPIC);
+	if (is_vertex) {
+		const char *vtoken = r2ai_vertex_get_token (state);
+		if (!vtoken) {
+			goto cleanup;
+		}
+		args.api_key = vtoken;
+	} else if (prov->requires_api_key) {
 		api_key = r2ai_apikeys_get (provider);
 		if (api_key) {
 			args.api_key = api_key;
@@ -158,6 +167,12 @@ R_IPI R2AI_ChatResponse *r2ai_llmcall(RCorePluginSession *cps, R2AIArgs args) {
 	case R2AI_API_GEMINI:
 		res = r2ai_gemini (cps, args);
 		break;
+	case R2AI_API_VERTEX_GEMINI:
+		res = r2ai_vertex_gemini (cps, args);
+		break;
+	case R2AI_API_VERTEX_ANTHROPIC:
+		res = r2ai_vertex_anthropic (cps, args);
+		break;
 	case R2AI_API_OPENAI_COMPATIBLE:
 	case R2AI_API_OLLAMA:
 	default:
@@ -176,6 +191,7 @@ R_IPI R2AI_ChatResponse *r2ai_llmcall(RCorePluginSession *cps, R2AIArgs args) {
 	}
 
 cleanup:
+	free (api_key);
 	free (owned_model);
 	free (owned_provider);
 	free (owned_system_prompt);
@@ -185,6 +201,10 @@ cleanup:
 R_IPI const char *r2ai_get_provider_url(RCore *core, const char *provider) {
 	const R2AIProvider *p = r2ai_get_provider (provider);
 	if (!p) {
+		return NULL;
+	}
+
+	if (p->api_type == R2AI_API_VERTEX_GEMINI || p->api_type == R2AI_API_VERTEX_ANTHROPIC) {
 		return NULL;
 	}
 
@@ -212,6 +232,11 @@ R_IPI const char *r2ai_get_provider_url(RCore *core, const char *provider) {
 }
 R_IPI RList *r2ai_fetch_available_models(RCore *core, const char *provider) {
 	if (!provider) {
+		return NULL;
+	}
+	const R2AIProvider *pcheck = r2ai_get_provider (provider);
+	if (pcheck && (pcheck->api_type == R2AI_API_VERTEX_GEMINI || pcheck->api_type == R2AI_API_VERTEX_ANTHROPIC)) {
+		R_LOG_ERROR ("Model listing is not supported for Vertex AI providers");
 		return NULL;
 	}
 	const char *purl = r2ai_get_provider_url (core, provider);

--- a/src/meson.build
+++ b/src/meson.build
@@ -68,6 +68,7 @@ srcs = files(
   'apikeys.c',
   'claw.c',
   'gemini.c',
+  'vertex.c',
   'http.c',
   'json.c',
   'wizard.c',

--- a/src/r2ai.c
+++ b/src/r2ai.c
@@ -694,6 +694,10 @@ R_IPI bool r2ai_init(RCorePluginSession *cps) {
 	r_config_desc (core->config, "r2ai.auto.usejs", "Enable/disable the execute_js tool for auto mode (true/false)");
 	r_config_set_b (core->config, "r2ai.auto.slim", true);
 	r_config_desc (core->config, "r2ai.auto.slim", "Use slim mode for auto commands (temporarily disable asm.lines.fcn and scr.utf8)");
+	r_config_set (core->config, "r2ai.vertex.project", "");
+	r_config_desc (core->config, "r2ai.vertex.project", "Google Cloud project ID for Vertex AI (required for vertex provider)");
+	r_config_set (core->config, "r2ai.vertex.region", "us-central1");
+	r_config_desc (core->config, "r2ai.vertex.region", "Google Cloud region for Vertex AI (e.g. us-central1, europe-west1)");
 	r_config_set_b (core->config, "r2ai.debug", false);
 	r_config_desc (core->config, "r2ai.debug", "Enable debug output including API request/response details and curl commands");
 	r_config_set_b (core->config, "r2ai.async", false);
@@ -728,6 +732,8 @@ R_API bool r2ai_fini(RCorePluginSession *cps) {
 	r_config_rm (core->config, "r2ai.http.backend");
 	r_config_rm (core->config, "r2ai.http.use_files");
 	r_config_rm (core->config, "r2ai.auto.slim");
+	r_config_rm (core->config, "r2ai.vertex.project");
+	r_config_rm (core->config, "r2ai.vertex.region");
 	r_config_rm (core->config, "r2ai.debug");
 	r_config_rm (core->config, "r2ai.async");
 	r_config_rm (core->config, "r2ai.async.purge");
@@ -740,6 +746,8 @@ R_API bool r2ai_fini(RCorePluginSession *cps) {
 		state->tools = NULL;
 		r_vdb_free (state->db);
 		state->db = NULL;
+		free (state->vertex_token);
+		state->vertex_token = NULL;
 		free (state);
 		cps->data = NULL;
 	}

--- a/src/r2ai.h
+++ b/src/r2ai.h
@@ -175,6 +175,8 @@ typedef struct r2ai_state_t {
 	void *help_msg; // Global help message (from r2ai.c)
 	RVdb *db; // Vector database for embeddings
 	struct r2ai_task_queue_t *async; // Async task queue (from async.c)
+	char *vertex_token; // Cached Vertex AI OAuth2 token
+	time_t vertex_token_expiry; // When the cached token expires
 } R2AI_State;
 
 /**
@@ -343,6 +345,7 @@ R_IPI const char *r2ai_get_provider_url(RCore *core, const char *provider);
 
 // anthropic
 R_IPI R2AI_ChatResponse *r2ai_anthropic(RCorePluginSession *cps, R2AIArgs args);
+R_IPI R2AI_ChatResponse *r2ai_anthropic_parse_response(const char *json, char **error);
 
 // openai
 R_IPI R2AI_ChatResponse *r2ai_openai(RCorePluginSession *cps, R2AIArgs args);

--- a/src/r2ai_priv.h
+++ b/src/r2ai_priv.h
@@ -8,7 +8,9 @@ typedef enum {
 	R2AI_API_OPENAI_COMPATIBLE,
 	R2AI_API_ANTHROPIC,
 	R2AI_API_GEMINI,
-	R2AI_API_OLLAMA
+	R2AI_API_OLLAMA,
+	R2AI_API_VERTEX_GEMINI,
+	R2AI_API_VERTEX_ANTHROPIC
 } R2AI_API_Type;
 
 /* Async task subsystem (see ASYNC.md) */
@@ -86,6 +88,11 @@ R_IPI void r2ai_refresh_embeddings(RCorePluginSession *cps);
 R_API char *r2ai_apikeys_path(bool *exists);
 R_API void r2ai_apikeys_edit(RCorePluginSession *cps);
 R_API char *r2ai_apikeys_get(const char *provider);
+
+/* vertex.c */
+R_IPI const char *r2ai_vertex_get_token(R2AI_State *state);
+R_IPI R2AI_ChatResponse *r2ai_vertex_gemini(RCorePluginSession *cps, R2AIArgs args);
+R_IPI R2AI_ChatResponse *r2ai_vertex_anthropic(RCorePluginSession *cps, R2AIArgs args);
 
 /* claw.c - SOUL.md / IDENTITY.md personality files */
 #define R2AI_CLAW_HINT "use 'r2ai -ide' to edit or 'r2ai -id-' to delete"

--- a/src/test_vertex.sh
+++ b/src/test_vertex.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+# Offline smoke tests for the Vertex AI provider (no network required)
+PASS=0
+FAIL=0
+
+# Use empty rc to avoid user config interference
+R2ENV="R2_RCFILE=/dev/null"
+
+check() {
+	desc="$1"
+	expected="$2"
+	actual="$3"
+	if echo "$actual" | grep -q "$expected"; then
+		PASS=$((PASS+1))
+	else
+		FAIL=$((FAIL+1))
+		printf "FAIL: %s\n  expected: %s\n  got: %s\n" "$desc" "$expected" "$actual"
+	fi
+}
+
+# Provider enumeration
+providers=$(env $R2ENV r2 -qc 'r2ai -e r2ai.api=?' -- 2>/dev/null)
+check "vertex in provider list" "vertex" "$providers"
+check "vertex-anthropic in provider list" "vertex-anthropic" "$providers"
+
+# Config defaults
+region=$(env $R2ENV r2 -qc 'r2ai -e r2ai.vertex.region' -- 2>/dev/null)
+check "vertex.region default is us-central1" "us-central1" "$region"
+
+# Config roundtrip
+rt=$(env $R2ENV r2 -qc 'e r2ai.vertex.project=test-proj; e r2ai.vertex.region=europe-west4; r2ai -e r2ai.vertex.project; r2ai -e r2ai.vertex.region' -- 2>/dev/null)
+check "vertex config roundtrip project" "test-proj" "$rt"
+check "vertex config roundtrip region" "europe-west4" "$rt"
+
+# Error when project not set
+err=$(env $R2ENV r2 -qc 'e r2ai.api=vertex; e r2ai.vertex.project=; r2ai hello' -- 2>&1)
+check "error when project not set" "vertex.project" "$err"
+
+printf "\n%d passed, %d failed\n" "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/src/vertex.c
+++ b/src/vertex.c
@@ -1,0 +1,421 @@
+/* Copyright r2ai - 2023-2026 - pancake */
+
+#include "r2ai.h"
+
+#define R2AI_VERTEX_TOKEN_TTL 3300 /* 55 minutes, tokens are valid for ~60 */
+
+static char *vertex_fetch_token(void) {
+	char *version = r_sys_cmd_str ("gcloud version", NULL, NULL);
+	if (R_STR_ISEMPTY (version)) {
+		free (version);
+		R_LOG_ERROR ("gcloud CLI not found. Install it from https://cloud.google.com/sdk/docs/install");
+		return NULL;
+	}
+	free (version);
+	char *token = r_sys_cmd_str ("gcloud auth application-default print-access-token", NULL, NULL);
+	if (R_STR_ISEMPTY (token)) {
+		free (token);
+		R_LOG_ERROR ("gcloud is not authenticated. Run 'gcloud auth application-default login'");
+		return NULL;
+	}
+	r_str_trim (token);
+	if (R_STR_ISEMPTY (token)) {
+		free (token);
+		return NULL;
+	}
+	return token;
+}
+
+/* The returned pointer is owned by state and must NOT be freed by the caller */
+R_IPI const char *r2ai_vertex_get_token(R2AI_State *state) {
+	time_t now = time (NULL);
+	if (state->vertex_token && now < state->vertex_token_expiry) {
+		return state->vertex_token;
+	}
+	free (state->vertex_token);
+	state->vertex_token = vertex_fetch_token ();
+	state->vertex_token_expiry = state->vertex_token? now + R2AI_VERTEX_TOKEN_TTL: 0;
+	return state->vertex_token;
+}
+
+R_IPI R2AI_ChatResponse *r2ai_vertex_gemini(RCorePluginSession *cps, R2AIArgs args) {
+	RCore *core = cps->core;
+	char **error = args.error;
+
+	const char *project = r_config_get (core->config, "r2ai.vertex.project");
+	const char *region = r_config_get (core->config, "r2ai.vertex.region");
+	if (R_STR_ISEMPTY (project) || R_STR_ISEMPTY (region)) {
+		if (error) {
+			*error = strdup ("Set r2ai.vertex.project and r2ai.vertex.region first");
+		}
+		return NULL;
+	}
+
+	const char *model_name = R_STR_ISNOTEMPTY (args.model)
+		? args.model
+		: r_config_get (core->config, "r2ai.model");
+
+	RList *temp_msgs = r2ai_msgs_new ();
+	if (!temp_msgs) {
+		if (error) {
+			*error = strdup ("Failed to create temporary messages array");
+		}
+		return NULL;
+	}
+
+	const char *system_prompt = NULL;
+	if (R_STR_ISNOTEMPTY (args.system_prompt)) {
+		system_prompt = args.system_prompt;
+	} else {
+		system_prompt = r_config_get (core->config, "r2ai.system");
+	}
+
+	RListIter *iter;
+	R2AI_Message *msg;
+
+	if (args.messages) {
+		r_list_foreach (args.messages, iter, msg) {
+			r2ai_msgs_add (temp_msgs, msg);
+		}
+	} else {
+		R_LOG_WARN ("No messages");
+	}
+
+	if (error) {
+		*error = NULL;
+	}
+
+	char *auth_header = r_str_newf ("Authorization: Bearer %s", args.api_key);
+	const char *headers[] = {
+		"Content-Type: application/json",
+		auth_header,
+		NULL
+	};
+
+	char *vertex_url = r_str_newf (
+		"https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s"
+		"/publishers/google/models/%s:generateContent",
+		region, project, region, model_name);
+
+	PJ *pj = pj_new ();
+	pj_o (pj);
+
+	if (R_STR_ISNOTEMPTY (system_prompt)) {
+		pj_ko (pj, "systemInstruction");
+		pj_ka (pj, "parts");
+		pj_o (pj);
+		pj_ks (pj, "text", system_prompt);
+		pj_end (pj);
+		pj_end (pj);
+		pj_end (pj);
+	}
+
+	pj_ka (pj, "contents");
+	r_list_foreach (temp_msgs, iter, msg) {
+		pj_o (pj);
+		const char *role = "user";
+		if (!strcmp (msg->role, "assistant")) {
+			role = "model";
+		}
+		pj_ks (pj, "role", role);
+		pj_ka (pj, "parts");
+		pj_o (pj);
+		pj_ks (pj, "text", msg->content? msg->content: "");
+		pj_end (pj);
+		pj_end (pj);
+		pj_end (pj);
+	}
+	pj_end (pj);
+
+	pj_ko (pj, "generationConfig");
+	if (args.max_tokens > 0) {
+		pj_kn (pj, "maxOutputTokens", args.max_tokens);
+	}
+	if (args.temperature > 0) {
+		pj_kd (pj, "temperature", args.temperature);
+	}
+	pj_end (pj);
+
+	pj_end (pj);
+
+	char *request_json = pj_drain (pj);
+
+	char *tmpdir = r_file_tmpdir ();
+	char *req_path = r_str_newf ("%s" R_SYS_DIR "r2ai_vertex_gemini_request.json", tmpdir);
+	r_file_dump (req_path, (const ut8 *)request_json, strlen (request_json), 0);
+	R_LOG_DEBUG ("Full request saved to %s", req_path);
+	free (req_path);
+	free (tmpdir);
+
+	R_LOG_DEBUG ("Vertex Gemini API request data: %s", request_json);
+
+	if (r_config_get_b (core->config, "r2ai.debug")) {
+		RStrBuf *curl_cmd = r_strbuf_new ("curl -X POST");
+		int i;
+		for (i = 0; headers[i]; i++) {
+			if (r_str_startswith (headers[i], "Authorization:")) {
+				r_strbuf_append (curl_cmd, " -H \"Authorization: Bearer ****\"");
+			} else {
+				r_strbuf_appendf (curl_cmd, " -H \"%s\"", headers[i]);
+			}
+		}
+		r_strbuf_appendf (curl_cmd, " -d '%s' \"%s\"", request_json, vertex_url);
+		eprintf ("Curl command: %s\n", r_strbuf_get (curl_cmd));
+		r_strbuf_free (curl_cmd);
+	}
+
+	int code = 0;
+	char *response = r2ai_http_post (core, vertex_url, headers, request_json, &code, NULL);
+
+	free (request_json);
+	free (vertex_url);
+	free (auth_header);
+
+	if (code != 200) {
+		R_LOG_ERROR ("Vertex Gemini API error %d", code);
+		if (response) {
+			R_LOG_ERROR ("Vertex Gemini API error response: %s", response);
+		}
+		free (response);
+		r2ai_msgs_free (temp_msgs);
+		return NULL;
+	}
+
+	tmpdir = r_file_tmpdir ();
+	char *res_path = r_str_newf ("%s" R_SYS_DIR "r2ai_vertex_gemini_response.json", tmpdir);
+	r_file_dump (res_path, (const ut8 *)response, strlen (response), 0);
+	R_LOG_DEBUG ("Vertex Gemini API response saved to %s", res_path);
+	free (res_path);
+	free (tmpdir);
+
+	RJson *jres = r_json_parse (response);
+	if (!jres) {
+		if (error) {
+			*error = strdup ("Failed to parse Vertex Gemini response JSON");
+		}
+		free (response);
+		r2ai_msgs_free (temp_msgs);
+		return NULL;
+	}
+
+	const RJson *candidates = r_json_get (jres, "candidates");
+	if (!candidates || candidates->type != R_JSON_ARRAY || candidates->children.count == 0) {
+		r_json_free (jres);
+		free (response);
+		r2ai_msgs_free (temp_msgs);
+		return NULL;
+	}
+
+	const RJson *candidate = r_json_item (candidates, 0);
+	const RJson *content = r_json_get (candidate, "content");
+	const RJson *parts = r_json_get (content, "parts");
+
+	if (!parts || parts->type != R_JSON_ARRAY || parts->children.count == 0) {
+		r_json_free (jres);
+		free (response);
+		r2ai_msgs_free (temp_msgs);
+		return NULL;
+	}
+
+	const RJson *part = r_json_item (parts, 0);
+	const RJson *text = r_json_get (part, "text");
+
+	char *response_text = NULL;
+	if (text && text->type == R_JSON_STRING) {
+		response_text = strdup (text->str_value);
+	}
+
+	R2AI_Usage *usage = R_NEW0 (R2AI_Usage);
+	const RJson *usage_meta = r_json_get (jres, "usageMetadata");
+	if (usage_meta && usage_meta->type == R_JSON_OBJECT) {
+		const RJson *pt = r_json_get (usage_meta, "promptTokenCount");
+		const RJson *ct = r_json_get (usage_meta, "candidatesTokenCount");
+		const RJson *tt = r_json_get (usage_meta, "totalTokenCount");
+		if (pt && pt->type == R_JSON_INTEGER) {
+			usage->prompt_tokens = pt->num.u_value;
+		}
+		if (ct && ct->type == R_JSON_INTEGER) {
+			usage->completion_tokens = ct->num.u_value;
+		}
+		if (tt && tt->type == R_JSON_INTEGER) {
+			usage->total_tokens = tt->num.u_value;
+		}
+	}
+
+	r_json_free (jres);
+	free (response);
+	r2ai_msgs_free (temp_msgs);
+
+	if (!response_text) {
+		free (usage);
+		return NULL;
+	}
+
+	R2AI_Message *message = R_NEW0 (R2AI_Message);
+	message->role = strdup ("assistant");
+	message->content = response_text;
+
+	R2AI_ChatResponse *result = R_NEW0 (R2AI_ChatResponse);
+	result->message = message;
+	result->usage = usage;
+
+	return result;
+}
+
+/* Vertex Anthropic uses anthropic_version in body instead of header,
+ * and omits the model field from the request body */
+
+R_IPI R2AI_ChatResponse *r2ai_vertex_anthropic(RCorePluginSession *cps, R2AIArgs args) {
+	RCore *core = cps->core;
+	const char *model = args.model;
+	char **error = args.error;
+	RList *tools = args.tools;
+	RList *messages_input = args.messages;
+
+	const char *project = r_config_get (core->config, "r2ai.vertex.project");
+	const char *region = r_config_get (core->config, "r2ai.vertex.region");
+	if (R_STR_ISEMPTY (project) || R_STR_ISEMPTY (region)) {
+		if (error) {
+			*error = strdup ("Set r2ai.vertex.project and r2ai.vertex.region first");
+		}
+		return NULL;
+	}
+
+	const char *model_name = R_STR_ISNOTEMPTY (model)
+		? model
+		: r_config_get (core->config, "r2ai.model");
+
+	if (error) {
+		*error = NULL;
+	}
+
+	char *auth_header = r_str_newf ("Authorization: Bearer %s", args.api_key);
+	const char *headers[] = {
+		"Content-Type: application/json",
+		auth_header,
+		NULL
+	};
+
+	char *vertex_url = r_str_newf (
+		"https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s"
+		"/publishers/anthropic/models/%s:rawPredict",
+		region, project, region, model_name);
+
+	const char *system_message = NULL;
+	if (R_STR_ISNOTEMPTY (args.system_prompt)) {
+		system_message = args.system_prompt;
+	} else {
+		system_message = r_config_get (core->config, "r2ai.system");
+	}
+
+	char *messages_json = NULL;
+	if (messages_input && !r_list_empty (messages_input)) {
+		messages_json = r2ai_msgs_to_anthropic_json (messages_input);
+		if (!messages_json) {
+			if (error) {
+				*error = strdup ("Failed to convert messages to JSON");
+			}
+			free (auth_header);
+			free (vertex_url);
+			return NULL;
+		}
+	} else {
+		if (error) {
+			*error = strdup ("No input or messages provided");
+		}
+		free (auth_header);
+		free (vertex_url);
+		return NULL;
+	}
+
+	char *anthropic_tools_json = NULL;
+	if (tools && !r_list_empty (tools)) {
+		anthropic_tools_json = r2ai_tools_to_anthropic_json (tools);
+	}
+
+	PJ *pj = pj_new ();
+	pj_o (pj);
+	pj_ks (pj, "anthropic_version", "vertex-2023-10-16");
+	pj_kn (pj, "max_tokens", args.max_tokens? args.max_tokens: 4096);
+	if (args.thinking_tokens >= 1024) {
+		pj_ko (pj, "thinking");
+		pj_ks (pj, "type", "enabled");
+		pj_kn (pj, "budget_tokens", args.thinking_tokens);
+		pj_end (pj);
+	}
+	if (system_message) {
+		pj_ks (pj, "system", system_message);
+	}
+
+	pj_k (pj, "messages");
+	pj_raw (pj, messages_json);
+
+	if (anthropic_tools_json) {
+		pj_k (pj, "tools");
+		pj_raw (pj, anthropic_tools_json);
+		free (anthropic_tools_json);
+	}
+
+	pj_kb (pj, "stream", false);
+
+	pj_end (pj);
+
+	char *data = pj_drain (pj);
+	free (messages_json);
+
+	char *tmpdir = r_file_tmpdir ();
+	char *req_path = r_str_newf ("%s" R_SYS_DIR "r2ai_vertex_anthropic_request.json", tmpdir);
+	r_file_dump (req_path, (const ut8 *)data, strlen (data), 0);
+	R_LOG_DEBUG ("Full request saved to %s", req_path);
+	free (req_path);
+	free (tmpdir);
+
+	R_LOG_DEBUG ("Vertex Anthropic API request data: %s", data);
+
+	if (r_config_get_b (core->config, "r2ai.debug")) {
+		RStrBuf *curl_cmd = r_strbuf_new ("curl -X POST");
+		int i;
+		for (i = 0; headers[i]; i++) {
+			if (r_str_startswith (headers[i], "Authorization:")) {
+				r_strbuf_append (curl_cmd, " -H \"Authorization: Bearer ****\"");
+			} else {
+				r_strbuf_appendf (curl_cmd, " -H \"%s\"", headers[i]);
+			}
+		}
+		r_strbuf_appendf (curl_cmd, " -d '%s' \"%s\"", data, vertex_url);
+		eprintf ("Curl command: %s\n", r_strbuf_get (curl_cmd));
+		r_strbuf_free (curl_cmd);
+	}
+
+	int code = 0;
+	char *res = r2ai_http_post (core, vertex_url, headers, data, &code, NULL);
+	free (data);
+	free (auth_header);
+	free (vertex_url);
+
+	if (!res || code != 200) {
+		R_LOG_ERROR ("Vertex Anthropic API error %d", code);
+		if (error && res) {
+			*error = strdup (res);
+		} else if (error) {
+			*error = strdup ("Failed to get response from Vertex Anthropic API");
+		}
+		free (res);
+		return NULL;
+	}
+
+	tmpdir = r_file_tmpdir ();
+	char *res_path = r_str_newf ("%s" R_SYS_DIR "r2ai_vertex_anthropic_response.json", tmpdir);
+	r_file_dump (res_path, (const ut8 *)res, strlen (res), 0);
+	R_LOG_DEBUG ("Vertex Anthropic API response saved to %s", res_path);
+	free (res_path);
+	free (tmpdir);
+
+	if (r_config_get_b (core->config, "r2ai.debug")) {
+		R_LOG_DEBUG ("Vertex Anthropic API response: %s", res);
+	}
+
+	R2AI_ChatResponse *result = r2ai_anthropic_parse_response (res, error);
+	free (res);
+	return result;
+}


### PR DESCRIPTION
## Summary

Add Google Cloud Vertex AI as a provider, allowing users to authenticate via `gcloud` CLI instead of API keys. Supports both Gemini and Anthropic (Claude) models through Vertex AI endpoints.

- `vertex` provider: Gemini models via Vertex AI
- `vertex-anthropic` provider: Claude models via Vertex AI
- OAuth2 tokens fetched automatically from `gcloud auth print-access-token`
- Two new config vars: `r2ai.vertex.project` and `r2ai.vertex.region`

## Usage

```
# Vertex + Gemini
r2ai -e api=vertex
r2ai -e vertex.project=my-gcp-project
r2ai -e vertex.region=us-central1
r2ai -e model=gemini-2.5-flash
r2ai hello

# Vertex + Anthropic (Claude)
r2ai -e api=vertex-anthropic
r2ai -e vertex.project=my-gcp-project
r2ai -e vertex.region=us-east5
r2ai -e model=claude-sonnet-4-20250514
r2ai hello
```

No API key files needed. Requires `gcloud` CLI installed and authenticated.

## Changes

| File | Change |
|------|--------|
| `src/vertex.c` | New: Vertex Gemini + Vertex Anthropic implementations |
| `src/r2ai_priv.h` | `R2AI_API_VERTEX_GEMINI`, `R2AI_API_VERTEX_ANTHROPIC` enum + declarations |
| `src/llm.c` | Provider table, gcloud token auto-fetch, switch dispatch, dynamic URL |
| `src/r2ai.c` | Config vars init/fini |
| `src/Makefile` | `vertex.o` |
| `src/meson.build` | `vertex.c` |

## Test results

All tested on macOS arm64, radare2 6.1.5. Uses only cross-platform radare2 APIs (`r_sys_cmd_str`, etc.) so it works on all supported platforms.

| Test | Result |
|------|--------|
| Providers listed (`r2ai -e r2ai.api=?`) | PASS |
| Config defaults (project empty, region us-central1) | PASS |
| Vertex Gemini simple query | PASS |
| Vertex Gemini decompilation (`-d`) | PASS |
| Vertex Gemini auto mode (`-a`) with tool calls | PASS |
| Error when project not set | PASS |
| Error when gcloud not available | PASS |
| Vertex Anthropic reaches correct endpoint | PASS (404 = project access, not code bug) |
| No regression: existing providers | PASS |
| Debug mode curl output | PASS |
| Config set/get roundtrip | PASS |