### PR TITLE
fix: Harden voice.py ffmpeg invocation by avoiding shell execution

### DIFF
--- a/Attic/py/r2ai/voice.py
+++ b/Attic/py/r2ai/voice.py
@@ -2,9 +2,7 @@
 
 import os
 import re
-import subprocess
 from .utils import syscmdstr
-from subprocess import Popen, PIPE
 
 HAVE_WHISPER = False
 model = None
@@ -50,8 +48,21 @@ def stt(seconds, lang):
         return
     tts("(r2ai) listening for 5s... ", "digues?", lang)
     print(f"DEVICE IS {device}")
-    os.system("rm -f .audiomsg.wav")
-    rc = os.system(f"ffmpeg -f avfoundation -t 5 -i '{device}' .audiomsg.wav > /dev/null 2>&1")
+    try:
+        os.remove(".audiomsg.wav")
+    except OSError:
+        pass
+    _devnull = os.open(os.devnull, os.O_WRONLY)
+    _pid = os.fork()
+    if _pid == 0:
+        os.dup2(_devnull, 1)
+        os.dup2(_devnull, 2)
+        os.close(_devnull)
+        os.execvp("ffmpeg", ["ffmpeg", "-f", "avfoundation", "-t", "5", "-i", device, ".audiomsg.wav"])
+        os._exit(1)
+    os.close(_devnull)
+    _, _status = os.waitpid(_pid, 0)
+    rc = os.WEXITSTATUS(_status) if os.WIFEXITED(_status) else 1
     if rc != 0:
         tts("(r2ai)", "cannot record from microphone. missing permissions in terminal?", lang)
         return
@@ -60,7 +71,10 @@ def stt(seconds, lang):
         result = model.transcribe(".audiomsg.wav")
     else:
         result = model.transcribe(".audiomsg.wav", language=lang)
-    os.system("rm -f .audiomsg.wav")
+    try:
+        os.remove(".audiomsg.wav")
+    except OSError:
+        pass
     tts("(r2ai)", "ok", lang)
     text = result["text"].strip()
     if text == "you":
@@ -80,8 +94,18 @@ def tts(author, text, lang):
             festlang = "spanish"
         elif lang == "it":
             festlang = "italian"
-        p = Popen(['festival', '--tts', '--language', festlang], stdin=PIPE)
-        p.communicate(input=text)
+        _r_fd, _w_fd = os.pipe()
+        _pid = os.fork()
+        if _pid == 0:
+            os.dup2(_r_fd, 0)
+            os.close(_r_fd)
+            os.close(_w_fd)
+            os.execvp("festival", ["festival", "--tts", "--language", festlang])
+            os._exit(1)
+        os.close(_r_fd)
+        os.write(_w_fd, text.encode("utf-8") if isinstance(text, str) else text)
+        os.close(_w_fd)
+        os.waitpid(_pid, 0)
     else:
         if lang == "es":
             VOICE = "Marisol"
@@ -89,4 +113,8 @@ def tts(author, text, lang):
             VOICE = "Montse"
         else:
             VOICE = "Moira"
-        subprocess.run(["say", "-v", VOICE, clean_text])
+        _pid = os.fork()
+        if _pid == 0:
+            os.execvp("say", ["say", "-v", VOICE, clean_text])
+            os._exit(1)
+        os.waitpid(_pid, 0)

--- a/Attic/py/r2ai/voice.py
+++ b/Attic/py/r2ai/voice.py
@@ -2,7 +2,9 @@
 
 import os
 import re
+import subprocess
 from .utils import syscmdstr
+from subprocess import Popen, PIPE
 
 HAVE_WHISPER = False
 model = None
@@ -52,17 +54,12 @@ def stt(seconds, lang):
         os.remove(".audiomsg.wav")
     except OSError:
         pass
-    _devnull = os.open(os.devnull, os.O_WRONLY)
-    _pid = os.fork()
-    if _pid == 0:
-        os.dup2(_devnull, 1)
-        os.dup2(_devnull, 2)
-        os.close(_devnull)
-        os.execvp("ffmpeg", ["ffmpeg", "-f", "avfoundation", "-t", "5", "-i", device, ".audiomsg.wav"])
-        os._exit(1)
-    os.close(_devnull)
-    _, _status = os.waitpid(_pid, 0)
-    rc = os.WEXITSTATUS(_status) if os.WIFEXITED(_status) else 1
+    result = subprocess.run(
+        ["ffmpeg", "-f", "avfoundation", "-t", "5", "-i", device, ".audiomsg.wav"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL
+    )
+    rc = result.returncode
     if rc != 0:
         tts("(r2ai)", "cannot record from microphone. missing permissions in terminal?", lang)
         return
@@ -94,18 +91,8 @@ def tts(author, text, lang):
             festlang = "spanish"
         elif lang == "it":
             festlang = "italian"
-        _r_fd, _w_fd = os.pipe()
-        _pid = os.fork()
-        if _pid == 0:
-            os.dup2(_r_fd, 0)
-            os.close(_r_fd)
-            os.close(_w_fd)
-            os.execvp("festival", ["festival", "--tts", "--language", festlang])
-            os._exit(1)
-        os.close(_r_fd)
-        os.write(_w_fd, text.encode("utf-8") if isinstance(text, str) else text)
-        os.close(_w_fd)
-        os.waitpid(_pid, 0)
+        p = Popen(['festival', '--tts', '--language', festlang], stdin=PIPE)
+        p.communicate(input=text)
     else:
         if lang == "es":
             VOICE = "Marisol"
@@ -113,8 +100,4 @@ def tts(author, text, lang):
             VOICE = "Montse"
         else:
             VOICE = "Moira"
-        _pid = os.fork()
-        if _pid == 0:
-            os.execvp("say", ["say", "-v", VOICE, clean_text])
-            os._exit(1)
-        os.waitpid(_pid, 0)
+        subprocess.run(["say", "-v", VOICE, clean_text])


### PR DESCRIPTION
## Summary

This PR hardens the `Attic/py/r2ai/voice.py` microphone recording path by avoiding shell interpretation when invoking `ffmpeg`.

The previous code built an `ffmpeg` command string using the detected audio `device` value and executed it through `os.system()`. If that value were ever influenced by an unexpected device name or local configuration, shell metacharacters could be interpreted by the shell.

This change invokes `ffmpeg` using an argument vector instead, so the device value is passed as a literal argument rather than parsed by `/bin/sh`.

## Security impact

This should be treated as defensive hardening rather than a critical, remotely exploitable vulnerability:

- the affected file is under `Attic/`
- the maintainer has indicated this area is abandoned/legacy code
- the `device` value appears to come from local microphone/device discovery, not a remote attacker-controlled input path

## Notes

A smaller follow-up version could use `subprocess.run([...], shell=False, stdout=DEVNULL, stderr=DEVNULL)` for readability and portability.

## Changes
- `Attic/py/r2ai/voice.py`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
